### PR TITLE
Ct00a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,6 @@ project(ConsoleTetris)
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_executable(ConsoleTetris main.cpp)
+add_executable(ConsoleTetris main.cpp src/Terminal.cpp src/Terminal.h)
 
 add_subdirectory(google-tests)

--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ Console Tetris project for assignment
 
 
 ### Backlog
-00\
+
+<del>00\
 Console Rendering
 
-00.a\
+<del>00.a\
 As a Developer\
 I want to be able to render characters in a fixed resolution
+
 
 01\
 Menu\

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,18 @@
 #include <iostream>
+#include <thread>
+#include <chrono>
+#include "src/Terminal.h"
+short screenWidth = 80;
+short screenHeight = 30;
+using namespace std::chrono_literals;
 
 int main() {
-    std::cout << "Hello, World!" << std::endl;
-    return 0;
+    Terminal *terminal = new Terminal(screenWidth, screenHeight);
+
+    bool gameOver = false;
+    while(!gameOver) {
+        std::this_thread::sleep_for(5000ms); // Small Step = 1 Game Tick
+
+        gameOver = true;
+    }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -6,8 +6,22 @@ short screenWidth = 80;
 short screenHeight = 30;
 using namespace std::chrono_literals;
 
+int fieldWidth = screenWidth;
+int fieldHeight = screenHeight;
+unsigned char *playField = nullptr;
+
 int main() {
-    Terminal *terminal = new Terminal(screenWidth, screenHeight);
+    Terminal *terminal = Terminal::getInstance(screenWidth, screenHeight);
+
+    playField = new unsigned char[fieldWidth * fieldHeight]; // Create play field buffer
+    for (int x = 0; x < fieldWidth; x++) // Board Boundary
+        for (int y = 0; y < fieldHeight; y++)
+            playField[y * fieldWidth + x] = (x == 0 || x == fieldWidth - 1 || y == fieldHeight - 1) ? 9 : 0;
+
+    wchar_t *screen = new wchar_t[screenWidth*screenHeight];
+    for (int i = 0; i < screenWidth*screenHeight; i++) screen[i] = L'#';
+
+    terminal->render(screen);
 
     bool gameOver = false;
     while(!gameOver) {

--- a/src/Terminal.cpp
+++ b/src/Terminal.cpp
@@ -3,6 +3,7 @@
 Terminal::Terminal(short width, short height): bufferWidth(width), bufferHeight(height) {
     hStdOut = CreateConsoleScreenBuffer(GENERIC_READ | GENERIC_WRITE, 0, nullptr, CONSOLE_TEXTMODE_BUFFER, nullptr);
     bufferScreen = new SMALL_RECT {0,0,1,1};
+    dwBytesWritten = 0;
 
     initialiseTerminal();
 }
@@ -34,4 +35,8 @@ short Terminal::getBufferWidth() const {
 
 short Terminal::getBufferHeight() const {
     return bufferHeight;
+}
+
+void Terminal::render(wchar_t *screenToRender) {
+    WriteConsoleOutputCharacterW(hStdOut, screenToRender, bufferWidth * bufferHeight, {0,0}, &dwBytesWritten);
 }

--- a/src/Terminal.cpp
+++ b/src/Terminal.cpp
@@ -40,3 +40,17 @@ short Terminal::getBufferHeight() const {
 void Terminal::render(wchar_t *screenToRender) {
     WriteConsoleOutputCharacterW(hStdOut, screenToRender, bufferWidth * bufferHeight, {0,0}, &dwBytesWritten);
 }
+
+Terminal *Terminal::getInstance(const short &width, const short &height) {
+    if (nullptr == instance) {
+        instance = new Terminal(width, height);
+    }
+    return instance;
+}
+
+Terminal *Terminal::instance = nullptr;
+
+Terminal::~Terminal() {
+    delete bufferScreen;
+    delete instance;
+}

--- a/src/Terminal.cpp
+++ b/src/Terminal.cpp
@@ -1,0 +1,31 @@
+//
+// Created by LMLK-404 on 08/07/2023.
+//
+
+
+
+
+
+#include "Terminal.h"
+
+Terminal::Terminal() {
+    hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
+
+    GetConsoleMode(hStdOut, &dwMode);
+
+    initialiseTerminal();
+}
+
+DWORD Terminal::getDwMode() const {
+    return dwMode;
+}
+
+void Terminal::setDwMode(DWORD dwMode) {
+    Terminal::dwMode |= dwMode;
+}
+
+void Terminal::initialiseTerminal() {
+    setDwMode(ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+
+    SetConsoleMode(hStdOut, dwMode);
+}

--- a/src/Terminal.cpp
+++ b/src/Terminal.cpp
@@ -1,17 +1,8 @@
-//
-// Created by LMLK-404 on 08/07/2023.
-//
-
-
-
-
-
 #include "Terminal.h"
 
-Terminal::Terminal() {
-    hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
-
-    GetConsoleMode(hStdOut, &dwMode);
+Terminal::Terminal(short width, short height): bufferWidth(width), bufferHeight(height) {
+    hStdOut = CreateConsoleScreenBuffer(GENERIC_READ | GENERIC_WRITE, 0, nullptr, CONSOLE_TEXTMODE_BUFFER, nullptr);
+    bufferScreen = new SMALL_RECT {0,0,1,1};
 
     initialiseTerminal();
 }
@@ -25,7 +16,22 @@ void Terminal::setDwMode(DWORD dwMode) {
 }
 
 void Terminal::initialiseTerminal() {
-    setDwMode(ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+    SetConsoleWindowInfo(hStdOut, true, bufferScreen);
 
-    SetConsoleMode(hStdOut, dwMode);
+    COORD buffer_size = {bufferWidth, bufferHeight};
+    SetConsoleScreenBufferSize(hStdOut, buffer_size);
+
+    bufferScreen->Right = bufferWidth-1;
+    bufferScreen->Bottom = bufferHeight-1;
+    SetConsoleWindowInfo(hStdOut, true, bufferScreen);
+
+    SetConsoleActiveScreenBuffer(hStdOut);
+}
+
+short Terminal::getBufferWidth() const {
+    return bufferWidth;
+}
+
+short Terminal::getBufferHeight() const {
+    return bufferHeight;
 }

--- a/src/Terminal.h
+++ b/src/Terminal.h
@@ -8,18 +8,26 @@
 
 class Terminal {
 public:
-    Terminal();
+    Terminal(short width, short height);
 
     void initialiseTerminal();
 
-
-private:
-    HANDLE hStdOut{};
-    DWORD dwMode{};
-public:
     DWORD getDwMode() const;
 
     void setDwMode(DWORD dwMode);
 
+    short getBufferWidth() const;
+
+    void setBufferWidth(short bufferWidth);
+
+    short getBufferHeight() const;
+
+    void setBufferHeight(short bufferHeight);
+private:
+    HANDLE hStdOut{};
+    DWORD dwMode{};
+    short bufferWidth{};
+    short bufferHeight{};
+    SMALL_RECT *bufferScreen{};
 };
 #endif //CONSOLETETRIS_TERMINAL_H

--- a/src/Terminal.h
+++ b/src/Terminal.h
@@ -7,8 +7,15 @@
 #include <windows.h>
 
 class Terminal {
-public:
+private:
     Terminal(short width, short height);
+
+public:
+    Terminal(Terminal &other) = delete;
+    void operator=(const Terminal &) = delete;
+    ~Terminal();
+
+    static Terminal *getInstance(const short &width, const short &height);
 
     void initialiseTerminal();
 
@@ -26,6 +33,8 @@ public:
 
     void render(wchar_t *screenToRender);
 private:
+    static Terminal *instance;
+
     HANDLE hStdOut{};
     DWORD dwMode{};
     short bufferWidth{};

--- a/src/Terminal.h
+++ b/src/Terminal.h
@@ -23,11 +23,14 @@ public:
     short getBufferHeight() const;
 
     void setBufferHeight(short bufferHeight);
+
+    void render(wchar_t *screenToRender);
 private:
     HANDLE hStdOut{};
     DWORD dwMode{};
     short bufferWidth{};
     short bufferHeight{};
     SMALL_RECT *bufferScreen{};
+    DWORD dwBytesWritten{};
 };
 #endif //CONSOLETETRIS_TERMINAL_H

--- a/src/Terminal.h
+++ b/src/Terminal.h
@@ -1,0 +1,25 @@
+//
+// Created by LMLK-404 on 08/07/2023.
+//
+
+#ifndef CONSOLETETRIS_TERMINAL_H
+#define CONSOLETETRIS_TERMINAL_H
+#include <windows.h>
+
+class Terminal {
+public:
+    Terminal();
+
+    void initialiseTerminal();
+
+
+private:
+    HANDLE hStdOut{};
+    DWORD dwMode{};
+public:
+    DWORD getDwMode() const;
+
+    void setDwMode(DWORD dwMode);
+
+};
+#endif //CONSOLETETRIS_TERMINAL_H


### PR DESCRIPTION
Add Terminal class that is used to control setting of output buffer.

Allows to render a a pointer to a wchar_t array that is the same size of the buffer initialized with constructor parameter